### PR TITLE
Refactor policy manager, models, and API structure for proper service indexing and retrieval

### DIFF
--- a/cryptomesh/controllers/functions.py
+++ b/cryptomesh/controllers/functions.py
@@ -1,0 +1,25 @@
+from fastapi import APIRouter, Depends
+from typing import List
+from cryptomesh.models import FunctionModel
+from cryptomesh.services.functions import FunctionsService
+from cryptomesh.repositories.functions import FunctionsRepository
+from cryptomesh.db import get_collection
+
+router = APIRouter()
+
+def get_functions_service() -> FunctionsService:
+    service = FunctionsService(
+        repository=FunctionsRepository(
+            collection=get_collection("functions")
+        )
+    )
+    return service
+
+@router.get("/functions", response_model=List[FunctionModel])
+async def get_functions(
+    functions_service: FunctionsService = Depends(get_functions_service)
+):
+    """
+    Retrieve a list of all functions.
+    """
+    return await functions_service.get_all_functions()

--- a/cryptomesh/controllers/microservices.py
+++ b/cryptomesh/controllers/microservices.py
@@ -1,0 +1,25 @@
+from fastapi import APIRouter, Depends
+from typing import List
+from cryptomesh.models import MicroserviceModel
+from cryptomesh.services.microservices import MicroservicesService
+from cryptomesh.repositories.microservices import MicroservicesRepository
+from cryptomesh.db import get_collection
+
+router = APIRouter()
+
+def get_microservice_service() -> MicroservicesService:
+    service = MicroservicesService(
+        repository=MicroservicesRepository(
+            collection=get_collection("microservices")
+        )
+    )
+    return service
+
+@router.get("/microservices", response_model=List[MicroserviceModel])
+async def get_microservices(
+    microservices_service: MicroservicesService = Depends(get_microservice_service)
+):
+    """
+    Retrieve a list of all microservices.
+    """
+    return await microservices_service.get_all_microservices()

--- a/cryptomesh/controllers/services.py
+++ b/cryptomesh/controllers/services.py
@@ -1,9 +1,11 @@
 from fastapi import APIRouter,Depends
 from typing import List
-from models import ServiceModel
+from cryptomesh.models import ServiceModel
 from cryptomesh.services import ServicesService
 from cryptomesh.repositories import ServicesRepository
 from cryptomesh.db import get_collection
+from fastapi import status
+from fastapi import Body
 
 
 router = APIRouter()
@@ -25,4 +27,14 @@ async def get_services(
     Retrieve a list of all services.
     """
     return await services_service.get_all_services()
+
+@router.post("/services", response_model=ServiceModel, status_code=status.HTTP_201_CREATED)
+async def create_service(
+    service: ServiceModel = Body(...),
+    services_service: ServicesService = Depends(get_service_service)
+):
+    """
+    Create a new service and return the created service.
+    """
+    return await services_service.create_service(service)
 

--- a/cryptomesh/db/load_metadata.py
+++ b/cryptomesh/db/load_metadata.py
@@ -1,0 +1,50 @@
+# cryptomesh/db/load_metadata.py
+
+import asyncio
+from cryptomesh.policies import CMPolicyManager
+from cryptomesh.db import connect_to_mongo, get_collection, close_mongo_connection
+
+async def main():
+    await connect_to_mongo()
+
+    services_collection = get_collection("services")
+    microservices_collection = get_collection("microservices")
+    functions_collection = get_collection("functions")
+
+    manager = CMPolicyManager()
+    policy = manager.interpret()
+
+    for service_id, service in policy.services.items():
+        service_dict = service.model_dump(exclude_unset=True)
+        service_dict["id"] = service_id
+
+        # Insertar servicio con microservicios anidados
+        service_result = await services_collection.insert_one(service_dict)
+        service_db_id = str(service_result.inserted_id)
+        print(f"✅ Servicio '{service_id}' insertado con ID: {service_db_id}")
+
+        for ms_name, micro in service.microservices.items():
+            micro_dict = micro.model_dump(exclude_unset=True)
+            micro_dict["name"] = ms_name
+            micro_dict["service_id"] = service_id
+            micro_dict["microservice_id"] = f"{service_id}_{ms_name}"
+
+            ms_result = await microservices_collection.insert_one(micro_dict)
+            micro_id = str(ms_result.inserted_id)
+            print(f"  📦 Microservicio '{ms_name}' insertado con ID: {micro_id}")
+
+            for fn_name, fn in micro.functions.items():
+                fn_dict = fn.model_dump(exclude_unset=True)
+                fn_dict["function_id"] = f"{micro_dict['microservice_id']}_{fn_name}"
+                fn_dict["microservice_id"] = micro_dict["microservice_id"]
+                fn_dict["service_id"] = service_id
+
+                await functions_collection.insert_one(fn_dict)
+                print(f"    🔧 Función '{fn_name}' insertada con ID: {fn_dict['function_id']}")
+
+    await close_mongo_connection()
+
+if __name__ == "__main__":
+    asyncio.run(main())
+
+

--- a/cryptomesh/db/reset_db.py
+++ b/cryptomesh/db/reset_db.py
@@ -1,0 +1,17 @@
+# cryptomesh/db/reset_db.py
+
+import asyncio
+from cryptomesh.db import connect_to_mongo, get_collection, close_mongo_connection
+
+async def clear_all():
+    await connect_to_mongo()
+
+    for name in ["services", "microservices", "functions"]:
+        collection = get_collection(name)
+        result = await collection.delete_many({})
+        print(f"🧹 Colección '{name}' limpiada ({result.deleted_count} documentos eliminados)")
+
+    await close_mongo_connection()
+
+if __name__ == "__main__":
+    asyncio.run(clear_all())

--- a/cryptomesh/models/__init__.py
+++ b/cryptomesh/models/__init__.py
@@ -1,72 +1,48 @@
-from typing import List
+from typing import Dict, List, Optional
 from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
-    
 class SecurityPolicy(BaseModel):
-    """
-    SecurityPolicy defines the security roles required for accessing or managing a service.
-
-    Attributes
-    ----------
-    roles : List[str]
-        A list of role names that are allowed to interact with the service.
-    """
     roles: List[str]
+    requires_authentication: Optional[bool] = False
 
+class Resource(BaseModel):
+    ram: str
+    cpu: int
 
-class MicroserviceModel(BaseModel):
-    """
-    MicroserviceModel represents a microservice within a larger service.
+class StoragePath(BaseModel):
+    path: str
+    bucket_id: Optional[str] = None
 
-    This model is intended to be extended with additional attributes that describe
-    the microservice configuration, such as its name, resources, or specific functions.
-    """
-    pass
-
-
-class ServiceModel(BaseModel):
-    """
-    ServiceModel encapsulates the details of a service in the CryptoMesh architecture.
-
-    Attributes
-    ----------
-    id : str
-        A unique identifier for the service.
-    security_policy : SecurityPolicy
-        The security policy that governs access to the service.
-    microservices : List[MicroserviceModel]
-        A list of microservices that belong to this service.
-    """
-    id: str
-    security_policy: SecurityPolicy
-    microservices: List[MicroserviceModel]
-
+class Storage(BaseModel):
+    capacity: str
+    source: StoragePath
+    sink: StoragePath
 
 class FunctionModel(BaseModel):
-    """
-    FunctionModel represents an individual function within a microservice.
+    image: str
+    resources: Resource
+    storage: Storage
 
-    This model should be extended with attributes that define the function's behavior,
-    such as the container image, resources, storage requirements, etc.
-    """
-    pass
+class MicroserviceModel(BaseModel):
+    security_policy: Optional[SecurityPolicy]
+    resources: Optional[Resource]
+    functions: Dict[str, FunctionModel]
 
+class ServiceModel(BaseModel):
+    security_policy: SecurityPolicy
+    microservices: Dict[str, MicroserviceModel]
 
-class Policy(BaseModel):
-    """
-    Policy defines the overall configuration for the CryptoMesh system.
+class ConnectionModel(BaseModel):
+    from_: str = Field(..., alias="from")
+    to: List[str]
+    condition: str
+    event: Optional[str] = None 
 
-    It encapsulates the top-level identifier for the CryptoMesh configuration and a list of services.
-
-    Attributes
-    ----------
-    cryptomesh : str
-        A top-level identifier or version string for the CryptoMesh configuration.
-    services : List[ServiceModel]
-        A list of services that are defined in the CryptoMesh configuration.
-    """
+class PolicyModel(BaseModel):
     cryptomesh: str
-    services: List[ServiceModel]
+    services: Dict[str, ServiceModel]
+    connections: List[ConnectionModel]
 
 
 

--- a/cryptomesh/repositories/functions.py
+++ b/cryptomesh/repositories/functions.py
@@ -1,0 +1,14 @@
+from motor.motor_asyncio import AsyncIOMotorCollection
+from cryptomesh.models import FunctionModel
+
+
+class FunctionsRepository():
+    def __init__(self, collection: AsyncIOMotorCollection):
+        self.collection = collection
+
+    async def find_all(self) -> list[FunctionModel]:
+        functions = []
+        cursor = self.collection.find({})
+        async for document in cursor:
+            functions.append(FunctionModel(**document))
+        return functions

--- a/cryptomesh/repositories/microservices.py
+++ b/cryptomesh/repositories/microservices.py
@@ -1,0 +1,14 @@
+from motor.motor_asyncio import AsyncIOMotorCollection
+from cryptomesh.models import MicroserviceModel
+
+
+class MicroservicesRepository():
+    def __init__(self, collection: AsyncIOMotorCollection):
+        self.collection = collection
+
+    async def find_all(self) -> list[MicroserviceModel]:
+        microservices = []
+        cursor = self.collection.find({})
+        async for document in cursor:
+            microservices.append(MicroserviceModel(**document))
+        return microservices

--- a/cryptomesh/repositories/services.py
+++ b/cryptomesh/repositories/services.py
@@ -1,9 +1,8 @@
-
 from motor.motor_asyncio import AsyncIOMotorCollection
 from cryptomesh.models import ServiceModel
 
-class ServicesRepository():
-    def __init__(self,collection:AsyncIOMotorCollection):
+class ServicesRepository:
+    def __init__(self, collection: AsyncIOMotorCollection):
         self.collection = collection
 
     async def find_all(self) -> list[ServiceModel]:
@@ -16,6 +15,11 @@ class ServicesRepository():
         async for document in cursor:
             # Convert MongoDB ObjectId to string for the Pydantic model
             document["id"] = str(document.get("_id"))
+
+            # Validación para asegurar que 'microservices' existe y no cause errores
+            if "microservices" not in document:
+                document["microservices"] = {}
+
             services.append(ServiceModel(**document))
         return services
 

--- a/cryptomesh/server.py
+++ b/cryptomesh/server.py
@@ -1,5 +1,7 @@
 from fastapi import FastAPI
 from cryptomesh.controllers import services_router
+from cryptomesh.controllers.microservices import router as microservices_router
+from cryptomesh.controllers.functions import router as functions_router
 import uvicorn
 from contextlib import asynccontextmanager
 from cryptomesh.db import connect_to_mongo,close_mongo_connection
@@ -15,6 +17,8 @@ app = FastAPI(title="CryptoMesh API",lifespan=lifespan)
 
 # Include API routes from the service controller under /api/v1
 app.include_router(services_router, prefix="/api/v1")
+app.include_router(microservices_router, prefix="/api/v1")
+app.include_router(functions_router, prefix="/api/v1")
 
 if __name__ == "__main__":
     uvicorn.run(app, host="0.0.0.0", port=19000)

--- a/cryptomesh/services/functions.py
+++ b/cryptomesh/services/functions.py
@@ -1,0 +1,10 @@
+from cryptomesh.repositories.functions import FunctionsRepository
+from cryptomesh.models import FunctionModel
+
+
+class FunctionsService:
+    def __init__(self, repository: FunctionsRepository):
+        self.repository = repository
+
+    async def get_all_functions(self) -> list[FunctionModel]:
+        return await self.repository.find_all()

--- a/cryptomesh/services/microservices.py
+++ b/cryptomesh/services/microservices.py
@@ -1,0 +1,10 @@
+from cryptomesh.repositories.microservices import MicroservicesRepository
+from cryptomesh.models import MicroserviceModel
+
+
+class MicroservicesService:
+    def __init__(self, repository: MicroservicesRepository):
+        self.repository = repository
+
+    async def get_all_microservices(self) -> list[MicroserviceModel]:
+        return await self.repository.find_all()

--- a/tests/test_api_endpoints.py
+++ b/tests/test_api_endpoints.py
@@ -1,0 +1,12 @@
+import pytest
+from fastapi.testclient import TestClient
+from httpx import AsyncClient
+from cryptomesh.server import app
+
+
+@pytest.mark.asyncio
+async def test_get_services():
+    async with AsyncClient(base_url="http://localhost:19000") as ac:
+        response = await ac.get("/api/v1/services")
+        assert response.status_code == 200
+        assert isinstance(response.json(), list)

--- a/tests/test_mongo_crud.py
+++ b/tests/test_mongo_crud.py
@@ -1,0 +1,20 @@
+import pytest
+import asyncio
+from motor.motor_asyncio import AsyncIOMotorClient
+from cryptomesh.repositories.services import ServicesRepository
+from cryptomesh.models import ServiceModel, SecurityPolicy
+
+@pytest.mark.asyncio
+async def test_insert_service():
+    client = AsyncIOMotorClient("mongodb://localhost:27017")
+    db = client.cryptomesh_test
+    repo = ServicesRepository(collection=db.services)
+
+    service = ServiceModel(
+        security_policy=SecurityPolicy(roles=["test_role"], requires_authentication=True),
+        microservices={}
+    )
+    result = await repo.create(service)
+    
+    assert result.security_policy.roles == ["test_role"]
+    await db.services.delete_many({})

--- a/tests/test_policy_manager.py
+++ b/tests/test_policy_manager.py
@@ -1,8 +1,34 @@
 import pytest
 from cryptomesh.policies import CMPolicyManager
+from cryptomesh.models import PolicyModel, ServiceModel, MicroserviceModel, FunctionModel, Resource
 
-pm = CMPolicyManager()
 
-@pytest.mark.skip("")
 def test_policy_manager():
-    pass
+    pm = CMPolicyManager()
+    policy = pm.interpret()
+
+    assert policy.cryptomesh == "v1"
+    assert isinstance(policy.services, dict)
+    assert len(policy.services) > 0
+
+    for service_id, service in policy.services.items():
+        assert isinstance(service_id, str)
+        assert isinstance(service, ServiceModel)
+        assert isinstance(service.security_policy.roles, list)
+
+        assert isinstance(service.microservices, dict)
+        assert len(service.microservices) > 0
+
+        for ms_id, micro in service.microservices.items():
+            assert isinstance(ms_id, str)
+            assert isinstance(micro, MicroserviceModel)
+            assert isinstance(micro.resources, Resource)
+            assert isinstance(micro.functions, dict)
+            assert len(micro.functions) > 0
+
+            for fn_id, fn in micro.functions.items():
+                assert isinstance(fn, FunctionModel)
+                assert fn.image.endswith(".encrypt") or fn.image.startswith("rory:")
+
+
+    


### PR DESCRIPTION
Este pull request introduce una refactorización completa del proceso de manejo de metadatos en CryptoMesh. Los principales cambios e implementaciones son:

    ✅ Modelos Pydantic estructurados para Service, Microservice y Function, incluyendo políticas de seguridad, recursos y almacenamiento.

    ✅ Parseo de YAML y validación usando CMPolicyManager, respetando correctamente el esquema definido en example_1.yml.

    ✅ Integración con MongoDB mediante repositorios independientes para services, microservices y functions, promoviendo una arquitectura limpia y mantenible.

    ✅ Indexación de datos desde el YAML hacia MongoDB a través de load_metadata.py (sin exponer como endpoint).

    ✅ Endpoints REST API implementados:

        GET /api/v1/services

        GET /api/v1/microservices

        GET /api/v1/functions

    ✅ Pruebas automatizadas para:

        Validación y parseo del YAML

        Operaciones CRUD en MongoDB

        Comportamiento de los endpoints de la API