### PR TITLE
Feature/cryptomesh errors

### DIFF
--- a/cryptomesh/controllers/endpoints_controller.py
+++ b/cryptomesh/controllers/endpoints_controller.py
@@ -1,21 +1,13 @@
 from fastapi import APIRouter, Depends, HTTPException, status, Response
 from typing import List
-from cryptomesh.models import EndpointModel
 from cryptomesh.services.endpoints_services import EndpointsService
 from cryptomesh.repositories.endpoints_repository import EndpointsRepository
 from cryptomesh.repositories.security_policy_repository import SecurityPolicyRepository
 from cryptomesh.services.security_policy_service import SecurityPolicyService
 from cryptomesh.db import get_collection
 from cryptomesh.log.logger import get_logger
-from cryptomesh.errors import (
-    CryptoMeshError,
-    NotFoundError,
-    ValidationError,
-    InvalidYAML,
-    CreationError,
-    UnauthorizedError,
-    FunctionNotFound,
-)
+from cryptomesh.errors import handle_crypto_errors
+
 import time as T
 from cryptomesh.dtos.endpoints_dto import EndpointCreateDTO, EndpointResponseDTO, EndpointUpdateDTO
 
@@ -38,15 +30,12 @@ def get_endpoints_service() -> EndpointsService:
     summary="Crear un nuevo endpoint",
     description="Crea un nuevo endpoint en la base de datos."
 )
+@handle_crypto_errors
 async def create_endpoint(dto: EndpointCreateDTO, svc: EndpointsService = Depends(get_endpoints_service)):
     t1 = T.time()
-    try:
-        model = dto.to_model()
-        created = await svc.create_endpoint(model)
-    except ValidationError as e:
-        raise HTTPException(status_code=400, detail=e.to_dict())
-    except CryptoMeshError as e:
-        raise HTTPException(status_code=400, detail=e.to_dict())
+    model = dto.to_model()
+    created = await svc.create_endpoint(model)
+
     elapsed = round(T.time() - t1, 4)
     L.info({
         "event": "API.ENDPOINT.CREATED",
@@ -54,6 +43,7 @@ async def create_endpoint(dto: EndpointCreateDTO, svc: EndpointsService = Depend
         "time": elapsed
     })
     return EndpointResponseDTO.from_model(created)
+
 
 @router.get(
     "/endpoints/",
@@ -63,13 +53,12 @@ async def create_endpoint(dto: EndpointCreateDTO, svc: EndpointsService = Depend
     summary="Obtener todos los endpoints",
     description="Recupera todos los endpoints almacenados en la base de datos."
 )
+@handle_crypto_errors
 async def list_endpoints(svc: EndpointsService = Depends(get_endpoints_service)):
     t1 = T.time()
-    try:
-        endpoints = await svc.list_endpoints()
-    except CryptoMeshError as e:
-        raise HTTPException(status_code=500, detail=e.to_dict())
+    endpoints = await svc.list_endpoints()
     elapsed = round(T.time() - t1, 4)
+
     L.debug({
         "event": "API.ENDPOINT.LISTED",
         "count": len(endpoints),
@@ -85,24 +74,11 @@ async def list_endpoints(svc: EndpointsService = Depends(get_endpoints_service))
     summary="Obtener un endpoint por ID",
     description="Devuelve un endpoint específico dado su ID único."
 )
+@handle_crypto_errors
 async def get_endpoint(endpoint_id: str, svc: EndpointsService = Depends(get_endpoints_service)):
     t1 = T.time()
-    try:
-        endpoint = await svc.get_endpoint(endpoint_id)
-        if not endpoint:
-            raise NotFoundError(endpoint_id)
-    except NotFoundError as e:
-        elapsed = round(T.time() - t1, 4)
-        L.warning({
-            "event": "API.ENDPOINT.NOT_FOUND",
-            "endpoint_id": endpoint_id,
-            "time": elapsed
-        })
-        raise HTTPException(status_code=404, detail=e.to_dict())
-    except ValidationError as e:
-        raise HTTPException(status_code=400, detail=e.to_dict())
-    except CryptoMeshError as e:
-        raise HTTPException(status_code=500, detail=e.to_dict())
+    endpoint = await svc.get_endpoint(endpoint_id)
+
     elapsed = round(T.time() - t1, 4)
     L.info({
         "event": "API.ENDPOINT.FETCHED",
@@ -119,28 +95,14 @@ async def get_endpoint(endpoint_id: str, svc: EndpointsService = Depends(get_end
     summary="Actualizar un endpoint por ID",
     description="Actualiza completamente un endpoint existente."
 )
+@handle_crypto_errors
 async def update_endpoint(endpoint_id: str, dto: EndpointUpdateDTO, svc: EndpointsService = Depends(get_endpoints_service)):
     t1 = T.time()
-    try:
-        existing = await svc.get_endpoint(endpoint_id)
-        if not existing:
-            raise NotFoundError(endpoint_id)
+    existing = await svc.get_endpoint(endpoint_id)
 
-        updated_model = EndpointUpdateDTO.apply_updates(dto, existing)
-        updated = await svc.update_endpoint(endpoint_id, updated_model.model_dump(by_alias=True))
+    updated_model = EndpointUpdateDTO.apply_updates(dto, existing)
+    updated = await svc.update_endpoint(endpoint_id, updated_model.model_dump(by_alias=True))
 
-    except NotFoundError as e:
-        elapsed = round(T.time() - t1, 4)
-        L.error({
-            "event": "API.ENDPOINT.UPDATE.FAIL",
-            "endpoint_id": endpoint_id,
-            "time": elapsed
-        })
-        raise HTTPException(status_code=404, detail=e.to_dict())
-    except ValidationError as e:
-        raise HTTPException(status_code=400, detail=e.to_dict())
-    except CryptoMeshError as e:
-        raise HTTPException(status_code=500, detail=e.to_dict())
     elapsed = round(T.time() - t1, 4)
     L.info({
         "event": "API.ENDPOINT.UPDATED",
@@ -155,16 +117,11 @@ async def update_endpoint(endpoint_id: str, dto: EndpointUpdateDTO, svc: Endpoin
     summary="Eliminar un endpoint por ID",
     description="Elimina un endpoint de la base de datos según su ID."
 )
+@handle_crypto_errors
 async def delete_endpoint(endpoint_id: str, svc: EndpointsService = Depends(get_endpoints_service)):
     t1 = T.time()
-    try:
-        await svc.delete_endpoint(endpoint_id)
-    except NotFoundError as e:
-        raise HTTPException(status_code=404, detail=e.to_dict())
-    except ValidationError as e:
-        raise HTTPException(status_code=400, detail=e.to_dict())
-    except CryptoMeshError as e:
-        raise HTTPException(status_code=500, detail=e.to_dict())
+    await svc.delete_endpoint(endpoint_id)
+
     elapsed = round(T.time() - t1, 4)
     L.info({
         "event": "API.ENDPOINT.DELETED",

--- a/cryptomesh/controllers/function_result_controller.py
+++ b/cryptomesh/controllers/function_result_controller.py
@@ -5,15 +5,7 @@ from cryptomesh.services.function_result_service import FunctionResultService
 from cryptomesh.repositories.function_result_repository import FunctionResultRepository
 from cryptomesh.db import get_collection
 from cryptomesh.log.logger import get_logger
-from cryptomesh.errors import (
-    CryptoMeshError,
-    NotFoundError,
-    ValidationError,
-    InvalidYAML,
-    CreationError,
-    UnauthorizedError,
-    FunctionNotFound,
-)
+from cryptomesh.errors import handle_crypto_errors
 import time as T
 from cryptomesh.dtos.function_result_dto import FunctionResultCreateDTO, FunctionResultResponseDTO, FunctionResultUpdateDTO
 
@@ -33,15 +25,12 @@ def get_function_result_service() -> FunctionResultService:
     summary="Crear un nuevo function result",
     description="Crea un nuevo registro de resultado para una función en la base de datos."
 )
+@handle_crypto_errors
 async def create_function_result(dto:FunctionResultCreateDTO, svc: FunctionResultService = Depends(get_function_result_service)):
     t1 = T.time()
-    try:
-        model = dto.to_model()
-        created = await svc.create_result(model)
-    except ValidationError as e:
-        raise HTTPException(status_code=400, detail=e.to_dict())
-    except CryptoMeshError as e:
-        raise HTTPException(status_code=500, detail=e.to_dict())
+    model = dto.to_model()
+    created = await svc.create_result(model)
+
     elapsed = round(T.time() - t1, 4)
     L.info({
         "event": "API.FUNCTION_RESULT.CREATED",
@@ -58,12 +47,11 @@ async def create_function_result(dto:FunctionResultCreateDTO, svc: FunctionResul
     summary="Listar todos los function results",
     description="Recupera todos los registros de resultados de funciones almacenados en la base de datos."
 )
+@handle_crypto_errors
 async def list_function_results(svc: FunctionResultService = Depends(get_function_result_service)):
     t1 = T.time()
-    try:
-        results = await svc.list_results()
-    except CryptoMeshError as e:
-        raise HTTPException(status_code=500, detail=e.to_dict())
+    results = await svc.list_results()
+
     elapsed = round(T.time() - t1, 4)
     L.debug({
         "event": "API.FUNCTION_RESULT.LISTED",
@@ -80,24 +68,11 @@ async def list_function_results(svc: FunctionResultService = Depends(get_functio
     summary="Obtener function result por ID",
     description="Devuelve un registro de resultado de función específico dado su ID."
 )
+@handle_crypto_errors
 async def get_function_result(result_id: str, svc: FunctionResultService = Depends(get_function_result_service)):
     t1 = T.time()
-    try:
-        result = await svc.get_result(result_id)
-        if not result:
-            raise NotFoundError(result_id)
-    except NotFoundError as e:
-        elapsed = round(T.time() - t1, 4)
-        L.warning({
-            "event": "API.FUNCTION_RESULT.NOT_FOUND",
-            "result_id": result_id,
-            "time": elapsed
-        })
-        raise HTTPException(status_code=404, detail=e.to_dict())
-    except ValidationError as e:
-        raise HTTPException(status_code=400, detail=e.to_dict())
-    except CryptoMeshError as e:
-        raise HTTPException(status_code=500, detail=e.to_dict())
+    result = await svc.get_result(result_id)
+   
     elapsed = round(T.time() - t1, 4)
     L.info({
         "event": "API.FUNCTION_RESULT.FETCHED",
@@ -114,28 +89,13 @@ async def get_function_result(result_id: str, svc: FunctionResultService = Depen
     summary="Actualizar function result por ID",
     description="Actualiza un registro de resultado de función existente."
 )
+@handle_crypto_errors
 async def update_function_result(result_id: str, dto: FunctionResultUpdateDTO, svc: FunctionResultService = Depends(get_function_result_service)):
     t1 = T.time()
-    try:
-        existing = await svc.get_result(result_id)
-        if not existing:
-            raise NotFoundError(result_id)
+    existing = await svc.get_result(result_id)
+    updated_model = FunctionResultUpdateDTO.apply_updates(dto, existing)
+    updated = await svc.update_result(result_id, updated_model.model_dump(by_alias=True))
 
-        updated_model = FunctionResultUpdateDTO.apply_updates(dto, existing)
-        updated = await svc.update_result(result_id, updated_model.model_dump(by_alias=True))
-
-    except NotFoundError as e:
-        elapsed = round(T.time() - t1, 4)
-        L.error({
-            "event": "API.FUNCTION_RESULT.UPDATE.FAIL",
-            "result_id": result_id,
-            "time": elapsed
-        })
-        raise HTTPException(status_code=404, detail=e.to_dict())
-    except ValidationError as e:
-        raise HTTPException(status_code=400, detail=e.to_dict())
-    except CryptoMeshError as e:
-        raise HTTPException(status_code=500, detail=e.to_dict())
     elapsed = round(T.time() - t1, 4)
     L.info({
         "event": "API.FUNCTION_RESULT.UPDATED",
@@ -150,16 +110,11 @@ async def update_function_result(result_id: str, dto: FunctionResultUpdateDTO, s
     summary="Eliminar function result por ID",
     description="Elimina un registro de resultado de función de la base de datos según su ID."
 )
+@handle_crypto_errors
 async def delete_function_result(result_id: str, svc: FunctionResultService = Depends(get_function_result_service)):
     t1 = T.time()
-    try:
-        await svc.delete_result(result_id)
-    except NotFoundError as e:
-        raise HTTPException(status_code=404, detail=e.to_dict())
-    except ValidationError as e:
-        raise HTTPException(status_code=400, detail=e.to_dict())
-    except CryptoMeshError as e:
-        raise HTTPException(status_code=500, detail=e.to_dict())
+    await svc.delete_result(result_id)
+
     elapsed = round(T.time() - t1, 4)
     L.info({
         "event": "API.FUNCTION_RESULT.DELETED",

--- a/cryptomesh/errors.py
+++ b/cryptomesh/errors.py
@@ -1,3 +1,9 @@
+from fastapi import HTTPException
+from typing import Any, Callable
+from functools import wraps
+
+
+
 class CryptoMeshError(Exception):
     def __init__(self, message: str, code: int = 500):
         self.message = message
@@ -9,6 +15,21 @@ class CryptoMeshError(Exception):
             "message": self.message,
             "code": self.code
         }
+
+    def to_http_exception(self):
+        """
+        Convert to FastAPI HTTPException
+        """
+        return HTTPException(status_code=self.code, detail=self.to_dict())
+
+    @staticmethod
+    def from_exception(e: Exception)-> "CryptoMeshError":
+        """
+        Convert a generic exception to a CryptoMeshError
+        """
+        if isinstance(e, CryptoMeshError):
+            return e
+        return CryptoMeshError(message=str(e), code=500)
 
 
 class FunctionNotFound(CryptoMeshError):
@@ -40,3 +61,19 @@ class CreationError(CryptoMeshError):
     def __init__(self, entity_type: str, entity_id: str, original_exception: Exception):
         message = f"Error creating {entity_type} '{entity_id}': {str(original_exception)}"
         super().__init__(message=message, code=500)
+
+
+# Decorator
+def handle_crypto_errors(func: Callable) -> Callable:
+    """
+    Decorator to handle CryptoMeshError exceptions in FastAPI endpoints
+    """
+    @wraps(func)
+    async def wrapper(*args, **kwargs) -> Any:
+        try:
+            return await func(*args, **kwargs)
+        except CryptoMeshError as e:
+            raise e.to_http_exception()
+        except Exception as e:
+            raise CryptoMeshError.from_exception(e).to_http_exception()
+    return wrapper


### PR DESCRIPTION
Este PR implementa una clase de errores para la API de CryptoMesh, llamada CryptoMeshError.  
- Se agregaron los métodos `to_http_exception()` y `from_exception()` para simplificar la conversión de errores en las rutas de la API.  
- Se incluyó un decorador para envolver los endpoints, maneja la clase de errores y excepción genérica.
- Se actualizaron todos los controladores para usar el nuevo enfoque de manejo de errores, reduciendo código repetitivo.
