### PR TITLE
Bugfix/name validation

### DIFF
--- a/cryptomesh/controllers/endpoints_controller.py
+++ b/cryptomesh/controllers/endpoints_controller.py
@@ -145,7 +145,6 @@ async def delete_endpoint(endpoint_id: str, svc: EndpointsService = Depends(get_
 @router.post(
     "/deploy",
     response_model=EndpointResponseDTO,
-    # response_model_by_alias=True,
     status_code=status.HTTP_201_CREATED,
     summary="Desplegar un nuevo endpoint",
     description="Desplegar un nuevo endpoint en la infraestructura."
@@ -156,39 +155,31 @@ async def deploy_endpoint(
     svc: EndpointsService = Depends(get_endpoints_service)
 ):
     t1 = T.time()
-    endpoint_id = None
-    try:
-        model   = dto.to_model()
-        created = await svc.create_endpoint(model)
-        endpoint_id = created.endpoint_id
-        res     = await svc.deploy(endpoint_id=endpoint_id)
-        if res.is_err:
-            del_res = await svc.delete_endpoint(endpoint_id=model.endpoint_id)
-            L.error({
-                "event": "API.ENDPOINT.DEPLOY_FAILED",
-                "endpoint_id": model.endpoint_id,
-                "delete": del_res.is_ok,
-                "detail": str(res.unwrap_err())
-            })
-            raise HTTPException(status_code=500, detail=f"Failed to deploy endpoint: {model.endpoint_id} - {res.unwrap_err()}")
-        t1      = T.time()
-        elapsed = round(T.time() - t1, 4)
-        L.info({
-            "event": "API.ENDPOINT.DEPLOYED",
-            "endpoint_id": created.endpoint_id,
-            "time": elapsed
-        })
-        return EndpointResponseDTO.from_model(created)
+    model = dto.to_model()
+    created = await svc.create_endpoint(model)
+    res = await svc.deploy(endpoint_id=created.endpoint_id)
     
-    except Exception as e:
+    if res.is_err:
+        del_res = await svc.delete_endpoint(endpoint_id=created.endpoint_id)
         L.error({
-            "event": "API.ENDPOINT.DEPLOY_EXCEPTION",
-            "endpoint_id": endpoint_id,
-            "detail": str(e)
+            "event": "API.ENDPOINT.DEPLOY_FAILED",
+            "endpoint_id": created.endpoint_id,
+            "delete": del_res.is_ok,
+            "detail": str(res.unwrap_err())
         })
-        if endpoint_id:
-            res = await svc.delete_endpoint(endpoint_id=endpoint_id)
-        raise HTTPException(status_code=400, detail=str(e))
+        raise HTTPException(
+            status_code=500,
+            detail=f"Failed to deploy endpoint: {created.endpoint_id} - {res.unwrap_err()}"
+        )
+
+    elapsed = round(T.time() - t1, 4)
+    L.info({
+        "event": "API.ENDPOINT.DEPLOYED",
+        "endpoint_id": created.endpoint_id,
+        "time": elapsed
+    })
+    return EndpointResponseDTO.from_model(created)
+
     
     # res = await Sum
 
@@ -198,6 +189,7 @@ async def deploy_endpoint(
     summary="Eliminar un endpoint",
     description="Eliminar un endpoint de la infraestructura."
 )
+@handle_crypto_errors
 async def detach_endpoint(
     endpoint_id:str,
     svc: EndpointsService = Depends(get_endpoints_service)

--- a/cryptomesh/models/__init__.py
+++ b/cryptomesh/models/__init__.py
@@ -1,6 +1,16 @@
 from datetime import datetime,timezone
 from pydantic import BaseModel, Field, ConfigDict, validator, field_validator
 from typing import List, Dict, Optional,Any
+from cryptomesh.validators.validators import (
+    ServiceNameStr,
+    MicroserviceNameStr,
+    RoleNameStr,
+    EndpointNameStr,
+    SecurityPolicyNameStr,
+    paramNameStr,
+    FunctionNameStr,
+    AxoNameStr
+)
 import uuid
 
 class SummonerParams(BaseModel):
@@ -21,22 +31,25 @@ class StorageModel(BaseModel):
     sink_path: str
 
 class RoleModel(BaseModel):
+    model_config = ConfigDict(validate_assignment=True)
     role_id: str = Field(default_factory=lambda: str(uuid.uuid4()))
-    name: str
+    name: RoleNameStr
     description: str
     permissions: List[str]
     created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
 
 class SecurityPolicyModel(BaseModel):
+    model_config = ConfigDict(validate_assignment=True)
     sp_id: str = Field(default_factory=lambda: str(uuid.uuid4()))
-    name: str
+    name: SecurityPolicyNameStr
     roles: List[str]  # Referencias a RoleModel
     requires_authentication: bool
     created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
 
 class EndpointModel(BaseModel):
+    model_config = ConfigDict(validate_assignment=True)
     endpoint_id: str = Field(default_factory=lambda: str(uuid.uuid4()))
-    name: str
+    name: EndpointNameStr
     image: str
     resources: ResourcesModel # resource_id
     security_policy: str  # sp_id
@@ -53,16 +66,18 @@ class EndpointStateModel(BaseModel):
     timestamp: datetime = Field(default_factory=lambda:datetime.now(timezone.utc))
 
 class ServiceModel(BaseModel):
+    model_config = ConfigDict(validate_assignment=True)
     service_id: str = Field(default_factory=lambda: str(uuid.uuid4()))
-    name: str
+    name: ServiceNameStr
     security_policy: str # sp_id
     resources: ResourcesModel  # resource_id
     created_at: datetime = Field(default_factory=lambda:datetime.now(timezone.utc))
     policy_id: Optional[str] = None
 
 class MicroserviceModel(BaseModel):
+    model_config = ConfigDict(validate_assignment=True)
     microservice_id: str = Field(default_factory=lambda: str(uuid.uuid4()))
-    name: str
+    name: MicroserviceNameStr
     service_id: str
     resources: ResourcesModel  # resource_id
     created_at: datetime = Field(default_factory=lambda:datetime.now(timezone.utc))
@@ -71,15 +86,17 @@ class MicroserviceModel(BaseModel):
 
 class ParameterSpec(BaseModel):
     """Esquema de un parámetro de función"""
-    name: str                           # nombre del parámetro
+    model_config = ConfigDict(validate_assignment=True)
+    name: paramNameStr                       # nombre del parámetro
     type: str                           # tipo esperado (str, int, DiGraph, etc.)
     description: Optional[str] = None   # descripción opcional
     required: bool = True               # si es obligatorio
     default: Optional[Any] = None       # valor por defecto
 
 class FunctionModel(BaseModel):
+    model_config = ConfigDict(validate_assignment=True)
     function_id: str = Field(default_factory=lambda: str(uuid.uuid4()))
-    name: str                          # ej. "run"
+    name: FunctionNameStr                         # ej. "run"
     init_params: List[ParameterSpec] = Field(default_factory=list)  # kwargs de __init__
     call_params: List[ParameterSpec] = Field(default_factory=list)   # kwargs de la función
     
@@ -112,7 +129,7 @@ class ActiveObjectModel(BaseModel):
     axo_dependencies: List[str] = Field(default_factory=list)
     
     axo_uri: Optional[str] = None
-    axo_alias: Optional[str] = None
+    axo_alias: AxoNameStr
     axo_code: Optional[str] = None
     axo_schema: Optional[Dict[str, object]] = Field(
         default=None,

--- a/cryptomesh/validators/validators.py
+++ b/cryptomesh/validators/validators.py
@@ -1,0 +1,25 @@
+from typing import Annotated, Callable
+from pydantic import AfterValidator
+
+# Definir un valor máximo global
+MAX_LEN = 32
+
+def max_length_validator(max_len: int, field_label: str) -> Callable[[str], str]:
+    """Crea un validador que revisa que la longitud de una cadena no exceda `max_len`."""
+    def validator_name(value: str) -> str:
+        if len(value) > max_len:
+            raise ValueError(f"{field_label} cannot exceed {max_len} characters.")
+        return value
+    return validator_name
+
+# Tipos anotados reutilizables con MAX_LEN
+ServiceNameStr = Annotated[str, AfterValidator(max_length_validator(MAX_LEN, "Service name"))]
+MicroserviceNameStr = Annotated[str, AfterValidator(max_length_validator(MAX_LEN, "Microservice name"))]
+RoleNameStr = Annotated[str, AfterValidator(max_length_validator(MAX_LEN, "Role name"))]
+EndpointNameStr = Annotated[str, AfterValidator(max_length_validator(MAX_LEN, "Endpoint name"))]
+SecurityPolicyNameStr = Annotated[str, AfterValidator(max_length_validator(MAX_LEN, "Security Policy name"))]
+paramNameStr = Annotated[str, AfterValidator(max_length_validator(MAX_LEN, "Parameter name"))]
+FunctionNameStr = Annotated[str, AfterValidator(max_length_validator(MAX_LEN, "Function name"))]
+AxoNameStr = Annotated[str, AfterValidator(max_length_validator(MAX_LEN, "Axo alias"))]
+
+


### PR DESCRIPTION
# PR Description
Este pull request introduce validación de nombres de entidades y en el manejo de errores del backend. Los cambios buscan garantizar la seguridad en los datos y una comunicación clara de errores hacia el frontend.

## Cambios principales:

1. **Módulo de Validadores (`validators`)**
   - Se creó un módulo reutilizable para validacion en el campo nombre de los modelos.
   - Se implementó un validador que asegura que los nombres de las entidades (Services, Endpoints, Roles, etc.) no excedan los 32 caracteres.
   - Este validador se aplica en los modelos Pydantic correspondientes.

2. **Modelos Pydantic**
   - Actualización de los modelos para incorporar la validación de longitud en los campos de nombre.
   - Mejora la consistencia de los datos almacenados en el backend.

3. **Controladores y manejo de errores**
   - Los controladores ahora devuelven un `400 Bad Request` si la validación de nombres falla.
   - Se estandarizó la respuesta de error en formato JSON con un mensaje claro y conciso (por ejemplo: `{'detail': 'The service name cannot exceed 32 characters.'}`), facilitando que el frontend muestre los errores correctamente.

## Beneficios
- Previene que usuarios malintencionados eludan la validación del frontend.
- Mejora la robustez y seguridad del backend.
- Facilita la integración con el frontend, mostrando errores consistentes y comprensibles.